### PR TITLE
Make calls and print outputs

### DIFF
--- a/components/ABIInput.tsx
+++ b/components/ABIInput.tsx
@@ -2,29 +2,19 @@ import { useEffect, useState } from 'react'
 import { Interface } from '@ethersproject/abi'
 
 import StackableContainer from './StackableContainer'
-import { NetworkId, useAbiFetch } from './useAbiFetch'
-import Address from './Address'
-import Network from './Network'
 
 type Props = {
+  fetchedAbiText: string | null
   onChange(abi: Interface | null): void
 }
 
-const ABIInput = ({ onChange }: Props) => {
-  const [network, setNetwork] = useState<NetworkId>('1')
-  const [address, setAddress] = useState('')
+const ABIInput = ({ fetchedAbiText, onChange }: Props) => {
   const [abiText, setAbiText] = useState('')
   const [syntaxError, setSyntaxError] = useState(false)
 
-  const {
-    abiText: fetchedAbiText,
-    success: success,
-    error: error,
-  } = useAbiFetch({ address, network })
-
   useEffect(() => {
     try {
-      const abi = parseAbiText(success ? fetchedAbiText : abiText)
+      const abi = parseAbiText(fetchedAbiText || abiText)
       setSyntaxError(false)
       onChange(abi)
     } catch (error) {
@@ -32,26 +22,19 @@ const ABIInput = ({ onChange }: Props) => {
       setSyntaxError(true)
       onChange(null)
     }
-  }, [abiText, fetchedAbiText, success])
+  }, [abiText, fetchedAbiText])
 
   return (
     <>
       <StackableContainer inputContainer lessMargin>
-        <Network onChange={setNetwork} />
-        <Address value={address} onChange={setAddress} />
-        {error && (
-          <span className="error">ABI for address could not be retrieved</span>
-        )}
-      </StackableContainer>
-      <StackableContainer inputContainer lessMargin>
         <label htmlFor="ABI-input">
-          {success ? 'ABI from explorer' : 'Paste in ABI here'}
+          {fetchedAbiText ? 'ABI from explorer' : 'Paste in ABI here'}
         </label>
         <textarea
           id="ABI-input"
           className="ABI-input"
-          readOnly={success}
-          value={success ? fetchedAbiText : abiText}
+          readOnly={!!fetchedAbiText}
+          value={fetchedAbiText || abiText}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
             setAbiText(e.target.value)
           }}
@@ -80,17 +63,6 @@ const ABIInput = ({ onChange }: Props) => {
     </>
   )
 }
-
-// function sanitize(abiText: string) {
-//   try {
-//     const t = JSON.parse(abiText)
-//     const abi = new Interface(t)
-//     const r = abi.format(FormatTypes.FULL)
-//     return Array.isArray(r) ? r.join('\n') : r
-//   } catch (e) {
-//     return abiText
-//   }
-// }
 
 function parseAbiText(abiText: string) {
   if (abiText.trim().length === 0) {

--- a/components/ABIInput.tsx
+++ b/components/ABIInput.tsx
@@ -49,6 +49,7 @@ const ABIInput = ({ onChange }: Props) => {
         </label>
         <textarea
           id="ABI-input"
+          className="ABI-input"
           readOnly={success}
           value={success ? fetchedAbiText : abiText}
           onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -69,6 +70,13 @@ const ABIInput = ({ onChange }: Props) => {
           </div>
         </StackableContainer>
       )}
+
+      <style jsx>{`
+        .ABI-input {
+          resize: vertical;
+          white-space: pre;
+        }
+      `}</style>
     </>
   )
 }

--- a/components/Call.tsx
+++ b/components/Call.tsx
@@ -1,0 +1,133 @@
+import { FunctionFragment, Interface, Result } from '@ethersproject/abi'
+import { BigNumber } from '@ethersproject/bignumber'
+import { isBigNumberish } from '@ethersproject/bignumber/lib/bignumber'
+import { Bytes, hexlify, isBytesLike } from '@ethersproject/bytes'
+import { Contract } from '@ethersproject/contracts'
+import { JsonRpcProvider } from '@ethersproject/providers'
+
+import { useEffect, useState } from 'react'
+
+import { encode, InputValueMap, processInputValues } from './Encoder'
+import { NetworkId, RPC_URLS } from './networks'
+import StackableContainer from './StackableContainer'
+
+type Props = {
+  network: NetworkId
+  address: string
+  abi: Interface
+  fn: FunctionFragment
+  inputValues: InputValueMap
+}
+
+const Call = ({ network, address, abi, fn, inputValues }: Props) => {
+  const [result, setResult] = useState<Result | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const { calldata } = encode(abi, fn, inputValues)
+
+  useEffect(() => {
+    if (!address) {
+      return
+    }
+    let canceled = false
+
+    setError(null)
+    setResult(null)
+    const contract = new Contract(
+      address,
+      abi,
+      new JsonRpcProvider(RPC_URLS[network], parseInt(network))
+    )
+
+    contract.callStatic[fn.name](...processInputValues(fn, inputValues))
+      .then((result) => {
+        if (!canceled) {
+          console.log('call result', result)
+          setResult(result)
+        }
+      })
+      .catch((e) => {
+        console.error(e, { ...e })
+        setError(e.reason)
+      })
+
+    return () => {
+      canceled = true
+    }
+  }, [calldata, network, address])
+
+  if (error) {
+    return (
+      <StackableContainer>
+        <p>Execution reverted</p>
+        <StackableContainer inputContainer lessMargin>
+          <code>{error}</code>
+        </StackableContainer>
+      </StackableContainer>
+    )
+  }
+
+  if (!result) return null
+
+  if (!fn.outputs || fn.outputs.length === 0) {
+    return (
+      <StackableContainer>
+        <p>Call successful, no output</p>
+      </StackableContainer>
+    )
+  }
+
+  return (
+    <StackableContainer>
+      <p>Call result</p>
+      {Array.isArray(result) ? (
+        <ArrayValue value={result} />
+      ) : (
+        <StackableContainer inputContainer lessMargin>
+          <PrimitiveValue value={result} />
+        </StackableContainer>
+      )}
+    </StackableContainer>
+  )
+}
+
+export default Call
+
+const PrimitiveValue = ({
+  value,
+}: {
+  value: BigNumber | Bytes | string | boolean
+}) => {
+  if (isBytesLike(value)) {
+    return <input type="text" readOnly value={hexlify(value)} />
+  }
+
+  if (isBigNumberish(value)) {
+    return <input type="text" readOnly value={value.toString()} />
+  }
+
+  if (typeof value === 'boolean') {
+    return <input type="text" readOnly value={value ? 'true' : 'false'} />
+  }
+
+  return <input type="text" readOnly value={value} />
+}
+
+const ArrayValue = ({ value }: { value: any[] }) => {
+  const labels = Object.keys(value).filter((key) => isNaN(parseInt(key)))
+  return (
+    <>
+      {value.map((item, index) => (
+        <StackableContainer inputContainer lessMargin key={index}>
+          {labels[index] && <label>{labels[index]}</label>}
+          <>
+            {Array.isArray(item) ? (
+              <ArrayValue value={item} />
+            ) : (
+              <PrimitiveValue value={item} />
+            )}
+          </>
+        </StackableContainer>
+      ))}
+    </>
+  )
+}

--- a/components/Encoder.tsx
+++ b/components/Encoder.tsx
@@ -25,7 +25,7 @@ const ABIFunctionRenderer = ({ abi, fn, inputValues }: Props) => {
   return (
     <>
       <StackableContainer lessMargin inputContainer>
-        <label>Call Data</label>
+        <label>Call data</label>
         <textarea className="callData" disabled value={calldata} />
         <CopyToClipboard text={calldata}>
           <button className="copy-button">
@@ -58,6 +58,10 @@ const ABIFunctionRenderer = ({ abi, fn, inputValues }: Props) => {
           display: block;
           width: 16px;
         }
+
+        .callData {
+          resize: vertical;
+        }
       `}</style>
     </>
   )
@@ -77,6 +81,16 @@ export function isInputValid(input: ParamType, value: string): boolean {
   }
 }
 
+export function processInputValues(
+  fn: FunctionFragment,
+  inputValueMap: InputValueMap
+) {
+  const inputEntries = fn.inputs.map(
+    (input, i) => inputValueMap[inputId(fn, input, i)]
+  )
+  return inputEntries.map((entry) => entry?.value || '').map(maybeParseJSON)
+}
+
 export function encode(
   abi: Interface,
   fn: FunctionFragment,
@@ -94,9 +108,7 @@ export function encode(
     (entry) => entry?.isValid === true
   ).length
 
-  const inputValues = inputEntries
-    .map((entry) => entry?.value || '')
-    .map(maybeParseJSON)
+  const inputValues = processInputValues(fn, inputValueMap)
 
   try {
     calldata = abi.encodeFunctionData(fn.name, inputValues)

--- a/components/Encoder.tsx
+++ b/components/Encoder.tsx
@@ -77,7 +77,7 @@ export function isInputValid(input: ParamType, value: string): boolean {
   }
 }
 
-function encode(
+export function encode(
   abi: Interface,
   fn: FunctionFragment,
   inputValueMap: InputValueMap

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -133,12 +133,14 @@ const Layout = ({ children, title = 'This is the default title' }: Props) => (
       /* Works on Firefox*/
       * {
         scrollbar-width: thin;
+        scrollbar-height: thin;
         scrollbar-color: rgba(217, 212, 173, 0.8) rgba(217, 212, 173, 0.1);
       }
 
       /* Works on Chrome, Edge, and Safari */
       *::-webkit-scrollbar {
         width: 6px;
+        height: 6px;
       }
 
       *::-webkit-scrollbar-track {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -106,6 +106,7 @@ const Layout = ({ children, title = 'This is the default title' }: Props) => (
       input,
       textarea {
         font-family: 'Roboto Mono', monospace;
+        font-size: 0.85em;
         background: none;
         border: 1px solid white;
         box-sizing: border-box;
@@ -128,6 +129,11 @@ const Layout = ({ children, title = 'This is the default title' }: Props) => (
 
       input::placeholder {
         color: rgba(255, 255, 255, 0.3);
+      }
+
+      code {
+        font-family: 'Roboto Mono', monospace;
+        font-size: 0.85em;
       }
 
       /* Works on Firefox*/

--- a/components/Network.tsx
+++ b/components/Network.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
+import { NetworkId, NETWORK_NAMES } from './networks'
 import Select from './Select'
-import { NetworkId, NETWORK_NAMES } from './useAbiFetch'
 
 type Props = {
   onChange(networkId: NetworkId): void
@@ -8,7 +8,7 @@ type Props = {
 
 const options = Object.keys(NETWORK_NAMES).map((key) => ({
   value: key as NetworkId,
-  label: NETWORK_NAMES[key],
+  label: NETWORK_NAMES[key as NetworkId],
 }))
 
 const Network = ({ onChange }: Props) => {

--- a/components/StackableContainer.tsx
+++ b/components/StackableContainer.tsx
@@ -9,7 +9,7 @@ type Props = {
   lessRadius?: boolean
 }
 
-export default (props: Props) => (
+const StackableContainer = (props: Props) => (
   <div
     className={`container ${props.base ? 'base' : ''} ${
       props.inputContainer ? 'input-container' : ''
@@ -73,3 +73,5 @@ export default (props: Props) => (
     `}</style>
   </div>
 )
+
+export default StackableContainer

--- a/components/networks.ts
+++ b/components/networks.ts
@@ -1,0 +1,46 @@
+export const BLOCK_EXPLORER_URLS = {
+  '1': 'https://api.etherscan.io/api',
+  '100': 'https://blockscout.com/xdai/mainnet/api',
+  '4': 'https://api-rinkeby.etherscan.io/api',
+  '5': 'https://api-goerli.etherscan.io/api',
+  '10': 'https://api-optimistic.etherscan.io/api',
+  '42220': 'https://explorer.celo.org/api',
+  '246': 'https://explorer.energyweb.org/api',
+  '73799': 'https://volta-explorer.energyweb.org/api',
+  '137': 'https://api.polygonscan.com/api',
+  '80001': 'https://api-testnet.polygonscan.com/api',
+  '56': 'https://api.bscscan.com/api',
+  '42161': 'https://api.arbiscan.io/api',
+}
+
+export type NetworkId = keyof typeof BLOCK_EXPLORER_URLS
+
+export const NETWORK_NAMES: Record<NetworkId, string> = {
+  '1': 'mainnet',
+  '100': 'xdai',
+  '4': 'rinkeby',
+  '5': 'görli',
+  '10': 'optimism',
+  '42220': 'celo',
+  '246': 'energyweb',
+  '73799': 'volta',
+  '137': 'polygon',
+  '80001': 'mumbai',
+  '56': 'bsc',
+  '42161': 'arbitrum',
+}
+
+export const RPC_URLS: Record<NetworkId, string> = {
+  '1': 'https://mainnet.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
+  '100': 'https://rpc.gnosischain.com',
+  '4': 'https://rinkeby.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
+  '5': 'https://goerli.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
+  '10': 'https://mainnet.optimism.io',
+  '42220': 'https://forno.celo.org',
+  '246': 'https://rpc.energyweb.org',
+  '73799': 'https://volta-rpc.energyweb.org',
+  '137': 'https://polygon-rpc.com',
+  '80001': 'https://rpc-mumbai.maticvigil.com',
+  '56': 'https://bsc-dataseed.binance.org',
+  '42161': 'https://arb1.arbitrum.io/rpc',
+}

--- a/components/useAbiFetch.tsx
+++ b/components/useAbiFetch.tsx
@@ -5,53 +5,7 @@ import { getAddress } from '@ethersproject/address'
 import detectProxyTarget from 'ethers-proxies'
 
 import { useEffect, useState } from 'react'
-
-const NETWORK_ULS = {
-  '1': 'https://api.etherscan.io/api',
-  '100': 'https://blockscout.com/xdai/mainnet/api',
-  '4': 'https://api-rinkeby.etherscan.io/api',
-  '5': 'https://api-goerli.etherscan.io/api',
-  '10': 'https://api-optimistic.etherscan.io/api',
-  '42220': 'https://explorer.celo.org/api',
-  '246': 'https://explorer.energyweb.org/api',
-  '73799': 'https://volta-explorer.energyweb.org/api',
-  '137': 'https://api.polygonscan.com/api',
-  '80001': 'https://api-testnet.polygonscan.com/api',
-  '56': 'https://api.bscscan.com/api',
-  '42161': 'https://api.arbiscan.io/api',
-}
-
-export const NETWORK_NAMES: { [key: string]: string } = {
-  '1': 'mainnet',
-  '100': 'xdai',
-  '4': 'rinkeby',
-  '5': 'görli',
-  '10': 'optimism',
-  '42220': 'celo',
-  '246': 'energyweb',
-  '73799': 'volta',
-  '137': 'polygon',
-  '80001': 'mumbai',
-  '56': 'bsc',
-  '42161': 'arbitrum',
-}
-
-const RPC_URLS = {
-  '1': 'https://mainnet.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
-  '100': 'https://rpc.gnosischain.com',
-  '4': 'https://rinkeby.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
-  '5': 'https://goerli.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
-  '10': 'https://mainnet.optimism.io',
-  '42220': 'https://forno.celo.org',
-  '246': 'https://rpc.energyweb.org',
-  '73799': 'https://volta-rpc.energyweb.org',
-  '137': 'https://polygon-rpc.com',
-  '80001': 'https://rpc-mumbai.maticvigil.com',
-  '56': 'https://bsc-dataseed.binance.org',
-  '42161': 'https://arb1.arbitrum.io/rpc',
-}
-
-export type NetworkId = keyof typeof NETWORK_ULS
+import { NetworkId, BLOCK_EXPLORER_URLS, RPC_URLS } from './networks'
 
 type Props = {
   address: string
@@ -141,7 +95,7 @@ export const fetchAbi = async (
   provider: Provider,
   blockExplorerApiKey = DEFAULT_ETHERSCAN_API_KEY
 ): Promise<{ abi: Interface | null; abiText: string }> => {
-  const apiUrl = NETWORK_ULS[network]
+  const apiUrl = BLOCK_EXPLORER_URLS[network]
   const params = new URLSearchParams({
     module: 'contract',
     action: 'getAbi',

--- a/components/useAbiFetch.tsx
+++ b/components/useAbiFetch.tsx
@@ -38,7 +38,7 @@ export const NETWORK_NAMES: { [key: string]: string } = {
 
 const RPC_URLS = {
   '1': 'https://mainnet.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
-  '100': 'https://dai.poa.network',
+  '100': 'https://rpc.gnosischain.com',
   '4': 'https://rinkeby.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
   '5': 'https://goerli.infura.io/v3/2d043e79a14e4145b4e07dd3eb3a5a4b',
   '10': 'https://mainnet.optimism.io',

--- a/package.json
+++ b/package.json
@@ -11,11 +11,12 @@
     "test": "jest --config ./test/jest.config.ts"
   },
   "dependencies": {
-    "@ethersproject/abi": "^5.0.0",
-    "@ethersproject/abstract-provider": "^5.5.1",
-    "@ethersproject/address": "^5.0.0",
-    "@ethersproject/bignumber": "^5.0.0",
-    "@ethersproject/providers": "^5.5.1",
+    "@ethersproject/abi": "^5.7.0",
+    "@ethersproject/abstract-provider": "^5.7.0",
+    "@ethersproject/address": "^5.7.0",
+    "@ethersproject/bignumber": "^5.7.0",
+    "@ethersproject/contracts": "^5.7.0",
+    "@ethersproject/providers": "^5.7.0",
     "@types/node-fetch": "^3.0.3",
     "@types/react-copy-to-clipboard": "^5.0.0",
     "@types/react-select": "^4.0.15",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "dependencies": {
     "@ethersproject/abi": "^5.7.0",
     "@ethersproject/abstract-provider": "^5.7.0",
-    "@ethersproject/address": "^5.7.0",
     "@ethersproject/bignumber": "^5.7.0",
+    "@ethersproject/bytes": "^5.7.0",
     "@ethersproject/contracts": "^5.7.0",
     "@ethersproject/providers": "^5.7.0",
     "@types/node-fetch": "^3.0.3",

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -4,7 +4,7 @@ const scriptTxt = `
 (function () {
   const { pathname } = window.location
   const ipfsMatch = /.*\\/Qm\\w{44}\\//.exec(pathname)
-  const ipnsMatch = /.*gnosisguild\.org\//.exec(pathname)
+  const ipnsMatch = /.*gnosisguild\.org\\//.exec(pathname)
   const base = document.createElement('base')
 
   if (ipfsMatch) {
@@ -19,12 +19,11 @@ const scriptTxt = `
 `
 
 class MyDocument extends Document {
-
   render() {
     return (
       <Html>
         <Head>
-            <script dangerouslySetInnerHTML={{__html: scriptTxt}}/>
+          <script dangerouslySetInnerHTML={{ __html: scriptTxt }} />
         </Head>
         <body>
           <Main />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,11 +7,18 @@ import ABIInput from '../components/ABIInput'
 import FunctionSelect from '../components/FunctionSelect'
 import Inputs from '../components/Inputs'
 import Encoder, { InputValueMap } from '../components/Encoder'
+import Address from '../components/Address'
+import Network from '../components/Network'
+import { NetworkId, useAbiFetch } from '../components/useAbiFetch'
 
 const IndexPage = () => {
+  const [network, setNetwork] = useState<NetworkId>('1')
+  const [address, setAddress] = useState('')
   const [abi, setAbi] = useState<Interface | null>(null)
   const [method, setMethod] = useState<string | null>(null)
   const [inputValues, setInputValues] = useState<InputValueMap>({})
+
+  const { abiText, success, error: error } = useAbiFetch({ address, network })
 
   return (
     <Layout title="Transaction Encoder">
@@ -22,7 +29,19 @@ const IndexPage = () => {
             Paste in the Contract Address or the ABI to render available
             functions.
           </p>
-          <ABIInput onChange={setAbi} />
+          <StackableContainer inputContainer lessMargin>
+            <Network onChange={setNetwork} />
+            <Address value={address} onChange={setAddress} />
+            {error && (
+              <span className="error">
+                ABI for address could not be retrieved
+              </span>
+            )}
+          </StackableContainer>
+          <ABIInput
+            fetchedAbiText={success ? abiText : null}
+            onChange={setAbi}
+          />
         </StackableContainer>
         {abi && <FunctionSelect abi={abi} onChange={setMethod} />}
         {abi && method && !!abi.functions[method] && (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,6 +10,7 @@ import Encoder, { InputValueMap } from '../components/Encoder'
 import Address from '../components/Address'
 import Network from '../components/Network'
 import { NetworkId, useAbiFetch } from '../components/useAbiFetch'
+import Call from '../components/Call'
 
 const IndexPage = () => {
   const [network, setNetwork] = useState<NetworkId>('1')
@@ -58,6 +59,16 @@ const IndexPage = () => {
               fn={abi.functions[method]}
               inputValues={inputValues}
             />
+
+            {address && network && (
+              <Call
+                network={network}
+                address={address}
+                abi={abi}
+                fn={abi.functions[method]}
+                inputValues={inputValues}
+              />
+            )}
           </>
         )}
       </StackableContainer>

--- a/yarn.lock
+++ b/yarn.lock
@@ -421,7 +421,22 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
-"@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.5.0", "@ethersproject/abstract-provider@^5.5.1":
+"@ethersproject/abi@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
+  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
+"@ethersproject/abstract-provider@^5.0.0", "@ethersproject/abstract-provider@^5.5.0":
   version "5.5.1"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.5.1.tgz#2f1f6e8a3ab7d378d8ad0b5718460f85649710c5"
   integrity sha512-m+MA/ful6eKbxpr99xUYeRvLkfnlqzrF8SZ46d/xFB1A7ZVknYc/sXJG0RcufF52Qn2jeFj1hhcoQ7IXjNKUqg==
@@ -434,6 +449,19 @@
     "@ethersproject/transactions" "^5.5.0"
     "@ethersproject/web" "^5.5.0"
 
+"@ethersproject/abstract-provider@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
+  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
+
 "@ethersproject/abstract-signer@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.5.0.tgz#590ff6693370c60ae376bf1c7ada59eb2a8dd08d"
@@ -444,6 +472,17 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
+
+"@ethersproject/abstract-signer@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
+  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/address@^5.0.0", "@ethersproject/address@^5.5.0":
   version "5.5.0"
@@ -456,6 +495,17 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/rlp" "^5.5.0"
 
+"@ethersproject/address@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
+  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+
 "@ethersproject/base64@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.5.0.tgz#881e8544e47ed976930836986e5eb8fab259c090"
@@ -463,13 +513,20 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
 
-"@ethersproject/basex@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.5.0.tgz#e40a53ae6d6b09ab4d977bd037010d4bed21b4d3"
-  integrity sha512-ZIodwhHpVJ0Y3hUCfUucmxKsWQA5TMnavp5j/UOuDdzZWzJlRmuOjcTMIGgHCYuZmHt36BfiSyQPSRskPxbfaQ==
+"@ethersproject/base64@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
+  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
+    "@ethersproject/bytes" "^5.7.0"
+
+"@ethersproject/basex@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/basex/-/basex-5.7.0.tgz#97034dc7e8938a8ca943ab20f8a5e492ece4020b"
+  integrity sha512-ywlh43GwZLv2Voc2gQVTKBoVQ1mti3d8HK5aMxsfu/nRDnMmNqaSJ3r3n85HBByT8OpoY96SXM1FogC533T4zw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
 
 "@ethersproject/bignumber@^5.0.0", "@ethersproject/bignumber@^5.5.0":
   version "5.5.0"
@@ -480,6 +537,15 @@
     "@ethersproject/logger" "^5.5.0"
     bn.js "^4.11.9"
 
+"@ethersproject/bignumber@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
+  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    bn.js "^5.2.1"
+
 "@ethersproject/bytes@^5.0.0", "@ethersproject/bytes@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
@@ -487,12 +553,26 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/bytes@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
+  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/constants@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.5.0.tgz#d2a2cd7d94bd1d58377d1d66c4f53c9be4d0a45e"
   integrity sha512-2MsRRVChkvMWR+GyMGY4N1sAX9Mt3J9KykCsgUFd/1mwS0UH1qw+Bv9k1UJb3X3YJYFco9H20pjSlOIfCG5HYQ==
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
+
+"@ethersproject/constants@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
+  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+  dependencies:
+    "@ethersproject/bignumber" "^5.7.0"
 
 "@ethersproject/contracts@^5.0.0":
   version "5.5.0"
@@ -510,6 +590,22 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/transactions" "^5.5.0"
 
+"@ethersproject/contracts@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.7.0.tgz#c305e775abd07e48aa590e1a877ed5c316f8bd1e"
+  integrity sha512-5GJbzEU3X+d33CdfPhcyS+z8MzsTrBGk/sc+G+59+tPa9yFkl6HQ9D6L0QMgNTA9q8dT0XKxxkyp883XsQvbbg==
+  dependencies:
+    "@ethersproject/abi" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+
 "@ethersproject/hash@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.5.0.tgz#7cee76d08f88d1873574c849e0207dcb32380cc9"
@@ -524,6 +620,21 @@
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
 
+"@ethersproject/hash@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
+  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+  dependencies:
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+
 "@ethersproject/keccak256@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.5.0.tgz#e4b1f9d7701da87c564ffe336f86dcee82983492"
@@ -532,10 +643,23 @@
     "@ethersproject/bytes" "^5.5.0"
     js-sha3 "0.8.0"
 
+"@ethersproject/keccak256@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
+  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    js-sha3 "0.8.0"
+
 "@ethersproject/logger@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
   integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
+
+"@ethersproject/logger@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
+  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
 
 "@ethersproject/networks@^5.5.0":
   version "5.5.0"
@@ -544,6 +668,13 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/networks@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
+  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
+  dependencies:
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/properties@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.5.0.tgz#61f00f2bb83376d2071baab02245f92070c59995"
@@ -551,38 +682,46 @@
   dependencies:
     "@ethersproject/logger" "^5.5.0"
 
-"@ethersproject/providers@^5.5.1":
-  version "5.5.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.5.1.tgz#ba87e3c93219bbd2e2edf8b369873aee774abf04"
-  integrity sha512-2zdD5sltACDWhjUE12Kucg2PcgM6V2q9JMyVvObtVGnzJu+QSmibbP+BHQyLWZUBfLApx2942+7DC5D+n4wBQQ==
+"@ethersproject/properties@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
+  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
   dependencies:
-    "@ethersproject/abstract-provider" "^5.5.0"
-    "@ethersproject/abstract-signer" "^5.5.0"
-    "@ethersproject/address" "^5.5.0"
-    "@ethersproject/basex" "^5.5.0"
-    "@ethersproject/bignumber" "^5.5.0"
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/constants" "^5.5.0"
-    "@ethersproject/hash" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
-    "@ethersproject/networks" "^5.5.0"
-    "@ethersproject/properties" "^5.5.0"
-    "@ethersproject/random" "^5.5.0"
-    "@ethersproject/rlp" "^5.5.0"
-    "@ethersproject/sha2" "^5.5.0"
-    "@ethersproject/strings" "^5.5.0"
-    "@ethersproject/transactions" "^5.5.0"
-    "@ethersproject/web" "^5.5.0"
+    "@ethersproject/logger" "^5.7.0"
+
+"@ethersproject/providers@^5.7.0":
+  version "5.7.2"
+  resolved "https://registry.yarnpkg.com/@ethersproject/providers/-/providers-5.7.2.tgz#f8b1a4f275d7ce58cf0a2eec222269a08beb18cb"
+  integrity sha512-g34EWZ1WWAVgr4aptGlVBF8mhl3VWjv+8hoAnzStu8Ah22VHBsuGzP17eb6xDVRzw895G4W7vvx60lFFur/1Rg==
+  dependencies:
+    "@ethersproject/abstract-provider" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.7.0"
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/basex" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/hash" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/networks" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/random" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/sha2" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/transactions" "^5.7.0"
+    "@ethersproject/web" "^5.7.0"
     bech32 "1.1.4"
     ws "7.4.6"
 
-"@ethersproject/random@^5.5.0":
-  version "5.5.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.5.0.tgz#305ed9e033ca537735365ac12eed88580b0f81f9"
-  integrity sha512-egGYZwZ/YIFKMHcoBUo8t3a8Hb/TKYX8BCBoLjudVCZh892welR3jOxgOmb48xznc9bTcMm7Tpwc1gHC1PFNFQ==
+"@ethersproject/random@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/random/-/random-5.7.0.tgz#af19dcbc2484aae078bb03656ec05df66253280c"
+  integrity sha512-19WjScqRA8IIeWclFme75VMXSBvi4e6InrUNuaR4s5pTF2qNhcGdCUwdxUVGtDDqC00sDLCO93jPQoDUH4HVmQ==
   dependencies:
-    "@ethersproject/bytes" "^5.5.0"
-    "@ethersproject/logger" "^5.5.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
 
 "@ethersproject/rlp@^5.5.0":
   version "5.5.0"
@@ -592,6 +731,14 @@
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/rlp@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
+  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/sha2@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.5.0.tgz#a40a054c61f98fd9eee99af2c3cc6ff57ec24db7"
@@ -599,6 +746,15 @@
   dependencies:
     "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
+    hash.js "1.1.7"
+
+"@ethersproject/sha2@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/sha2/-/sha2-5.7.0.tgz#9a5f7a7824ef784f7f7680984e593a800480c9fb"
+  integrity sha512-gKlH42riwb3KYp0reLsFTokByAKoJdgFCwI+CCiX/k+Jm2mbNs6oOaCjYQSlI1+XBVejwH2KrmCbMAT/GnRDQw==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
     hash.js "1.1.7"
 
 "@ethersproject/signing-key@^5.5.0":
@@ -610,6 +766,18 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     bn.js "^4.11.9"
+    elliptic "6.5.4"
+    hash.js "1.1.7"
+
+"@ethersproject/signing-key@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
+  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    bn.js "^5.2.1"
     elliptic "6.5.4"
     hash.js "1.1.7"
 
@@ -634,6 +802,15 @@
     "@ethersproject/constants" "^5.5.0"
     "@ethersproject/logger" "^5.5.0"
 
+"@ethersproject/strings@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
+  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+  dependencies:
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+
 "@ethersproject/transactions@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.5.0.tgz#7e9bf72e97bcdf69db34fe0d59e2f4203c7a2908"
@@ -649,6 +826,21 @@
     "@ethersproject/rlp" "^5.5.0"
     "@ethersproject/signing-key" "^5.5.0"
 
+"@ethersproject/transactions@^5.7.0":
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
+  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+  dependencies:
+    "@ethersproject/address" "^5.7.0"
+    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/constants" "^5.7.0"
+    "@ethersproject/keccak256" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/signing-key" "^5.7.0"
+
 "@ethersproject/web@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.5.0.tgz#0e5bb21a2b58fb4960a705bfc6522a6acf461e28"
@@ -659,6 +851,17 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
     "@ethersproject/strings" "^5.5.0"
+
+"@ethersproject/web@^5.7.0":
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
+  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+  dependencies:
+    "@ethersproject/base64" "^5.7.0"
+    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/strings" "^5.7.0"
 
 "@hapi/accept@5.0.2":
   version "5.0.2"
@@ -1470,6 +1673,11 @@ bn.js@^5.0.0, bn.js@^5.1.1:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.0.tgz#358860674396c6997771a9d051fcc1b57d4ae002"
   integrity sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==
+
+bn.js@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-5.2.1.tgz#0bc527a6a0d18d0aa8d5b0538ce4a77dccfa7b70"
+  integrity sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==
 
 brace-expansion@^1.1.7:
   version "1.1.11"


### PR DESCRIPTION
This PR adds sending of eth calls with the encoded calldata. This is useful for quick debugging. (I would have needed this recently to investigate a problem, but ended up using a more cumbersome setup with Remix)

Call with primitive output:

<img width="522" alt="image" src="https://user-images.githubusercontent.com/524089/200584781-519c9399-2d36-41d5-92a3-5182adcc822a.png">


Call with complex output:

<img width="601" alt="image" src="https://user-images.githubusercontent.com/524089/200584710-5c0a9753-e1ac-4ead-8f46-d403fbae2173.png">


Revert:

<img width="525" alt="image" src="https://user-images.githubusercontent.com/524089/200584559-b4dac8f1-59e0-4e42-970f-04eb98211502.png">
