### PR TITLE
fix an encoding bignumber overflow error

### DIFF
--- a/components/Encoder.tsx
+++ b/components/Encoder.tsx
@@ -77,6 +77,7 @@ export function isInputValid(input: ParamType, value: string): boolean {
     const result = defaultAbiCoder.encode([input.type], [maybeParseJSON(value)])
     return !!result
   } catch (e) {
+    console.warn('invalid input', e, { input, value })
     return false
   }
 }
@@ -130,7 +131,12 @@ export function encode(
 
 function maybeParseJSON(value: string) {
   try {
-    return JSON.parse(value)
+    const result = JSON.parse(value)
+    if (typeof result === 'number') {
+      // we want to keep numbers as strings to avoid overflow issues
+      return value
+    }
+    return result
   } catch (e) {
     return value
   }

--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -16,6 +16,7 @@ const Inputs = ({ fn, inputValues, onChange }: Props) => (
       {fn.inputs.map((input, i) => {
         const id = inputId(fn, input, i)
         const error = inputValues[id]?.value && !inputValues[id]?.isValid
+        console.log(error)
         return (
           <li key={id}>
             <StackableContainer inputContainer>

--- a/components/Inputs.tsx
+++ b/components/Inputs.tsx
@@ -16,7 +16,6 @@ const Inputs = ({ fn, inputValues, onChange }: Props) => (
       {fn.inputs.map((input, i) => {
         const id = inputId(fn, input, i)
         const error = inputValues[id]?.value && !inputValues[id]?.isValid
-        console.log(error)
         return (
           <li key={id}>
             <StackableContainer inputContainer>


### PR DESCRIPTION
There was a BigNumber overflow error when entering large values for uint256 parameters. That was because `maybeParseJSON` converted input strings into numbers (`parseJSON('1') === 1`).