### PR TITLE
enable abi formatting

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -68,6 +68,10 @@ const Layout = ({ children, title = 'This is the default title' }: Props) => (
       button {
         cursor: pointer;
       }
+      button:disabled {
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
       h1 {
         margin: 0;
         font-weight: 400;


### PR DESCRIPTION
This PR adds two buttons to the ABI input to format the value in json or human-readable format:

<img width="533" alt="image" src="https://user-images.githubusercontent.com/524089/206030840-8d748d44-f878-44a6-972e-94d589a532f1.png">
