### PR TITLE
Support function overloads

### DIFF
--- a/components/Call.tsx
+++ b/components/Call.tsx
@@ -38,7 +38,9 @@ const Call = ({ network, address, abi, fn, inputValues }: Props) => {
       new JsonRpcProvider(RPC_URLS[network], parseInt(network))
     )
 
-    contract.callStatic[fn.name](...processInputValues(fn, inputValues))
+    contract.callStatic[fn.format('sighash')](
+      ...processInputValues(fn, inputValues)
+    )
       .then((result) => {
         if (!canceled) {
           console.log('call result', result)

--- a/components/Encoder.tsx
+++ b/components/Encoder.tsx
@@ -69,7 +69,7 @@ const ABIFunctionRenderer = ({ abi, fn, inputValues }: Props) => {
 
 // ABI might have inputs without name
 export function inputId(fn: FunctionFragment, input: ParamType, i: number) {
-  return `${fn.name}-${input.name ? input.name : i}`
+  return `${fn.format('sighash')}-${input.name ? input.name : i}`
 }
 
 export function isInputValid(input: ParamType, value: string): boolean {
@@ -112,7 +112,7 @@ export function encode(
   const inputValues = processInputValues(fn, inputValueMap)
 
   try {
-    calldata = abi.encodeFunctionData(fn.name, inputValues)
+    calldata = abi.encodeFunctionData(fn.format('sighash'), inputValues)
     encodeError = ''
   } catch (error) {
     // show a console log if theres at least one filled input

--- a/components/FunctionSelect.tsx
+++ b/components/FunctionSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import Select from './Select'
-import { FunctionFragment, Interface } from '@ethersproject/abi'
+import { Interface } from '@ethersproject/abi'
 
 import StackableContainer from './StackableContainer'
 
@@ -48,11 +48,11 @@ const FunctionSelect = ({ abi, onChange }: Props) => {
     <StackableContainer lessMargin inputContainer>
       <label htmlFor="function-select-input">Select function to encode</label>
       <Select
-        options={options}
+        options={options as any}
         name="function-select"
         inputId="function-select-input"
-        onChange={(selected: { value: string; label: string }) => {
-          onChange((selected as { value: string; label: string }).value)
+        onChange={(selected) => {
+          onChange(selected?.value as string)
         }}
       />
     </StackableContainer>

--- a/components/FunctionSelect.tsx
+++ b/components/FunctionSelect.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import Select from './Select'
-import { Interface } from '@ethersproject/abi'
+import { FunctionFragment, Interface } from '@ethersproject/abi'
 
 import StackableContainer from './StackableContainer'
 
@@ -9,11 +9,37 @@ type Props = {
   onChange(method: string): void
 }
 
+const FunctionOption: React.FC<{ abi: Interface; fn: string }> = ({
+  abi,
+  fn,
+}) => {
+  const functionFragment = abi.functions[fn]
+  const params = functionFragment.format('full').split('(')[1].split(')')[0]
+  const isOverloaded =
+    abi.fragments.filter(
+      (fragment) =>
+        fragment.type === 'function' && fragment.name === functionFragment.name
+    ).length > 1
+
+  return (
+    <div className="option">
+      {functionFragment.name} {isOverloaded && <small>({params})</small>}
+      <style jsx>{`
+        .option {
+          white-space: nowrap;
+          overflow-x: ellipsis;
+        }
+        
+      }`}</style>
+    </div>
+  )
+}
+
 const FunctionSelect = ({ abi, onChange }: Props) => {
   const createOptions = (abi: Interface) =>
     Object.keys(abi.functions).map((key) => ({
       value: key,
-      label: abi.functions[key].name,
+      label: <FunctionOption abi={abi} fn={key} />,
     }))
 
   const options = createOptions(abi)

--- a/components/FunctionSelect.tsx
+++ b/components/FunctionSelect.tsx
@@ -27,9 +27,7 @@ const FunctionOption: React.FC<{ abi: Interface; fn: string }> = ({
       <style jsx>{`
         .option {
           white-space: nowrap;
-          overflow-x: ellipsis;
         }
-        
       }`}</style>
     </div>
   )

--- a/components/Network.tsx
+++ b/components/Network.tsx
@@ -18,7 +18,7 @@ const Network = ({ onChange }: Props) => {
       <Select
         defaultValue={options[0]}
         options={options}
-        onChange={(selected: { value: string }) => {
+        onChange={(selected) => {
           onChange((selected?.value as NetworkId) || '1')
         }}
         name="network-select"

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -14,6 +14,11 @@ const StyledSelect = (props: any) => {
         borderColor: 'rgba(217, 212, 173, 1)',
       },
     }),
+    input: (provided: React.CSSProperties) => ({
+      ...provided,
+      color: 'white',
+      fontSize: '0.85em',
+    }),
     option: (provided: React.CSSProperties, state: any) => ({
       ...provided,
       background: state.isSelected ? 'rgba(217, 212, 173, 0.5)' : 'none',

--- a/components/Select.tsx
+++ b/components/Select.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
-import Select from 'react-select'
+import Select, { Props } from 'react-select'
+import { CSSObject } from '@emotion/serialize'
 
-const StyledSelect = (props: any) => {
-  const customStyles = {
-    control: (provided: React.CSSProperties, state: any) => ({
+const StyledSelect: React.FC<Props> = (props) => {
+  const customStyles: Props['styles'] = {
+    control: (provided: CSSObject, state: any) => ({
       ...provided,
       borderRadius: 0,
       background: 'rgba(217, 212, 173, 0.01)',
@@ -14,12 +15,12 @@ const StyledSelect = (props: any) => {
         borderColor: 'rgba(217, 212, 173, 1)',
       },
     }),
-    input: (provided: React.CSSProperties) => ({
+    input: (provided: CSSObject) => ({
       ...provided,
       color: 'white',
       fontSize: '0.85em',
     }),
-    option: (provided: React.CSSProperties, state: any) => ({
+    option: (provided: CSSObject, state: any) => ({
       ...provided,
       background: state.isSelected ? 'rgba(217, 212, 173, 0.5)' : 'none',
       color: 'white',
@@ -28,13 +29,13 @@ const StyledSelect = (props: any) => {
         background: 'rgba(217, 212, 173, 0.2)',
       },
     }),
-    menu: (provided: React.CSSProperties) => ({
+    menu: (provided: CSSObject) => ({
       ...provided,
       zIndex: 10,
       borderRadius: 0,
       background: 'black',
     }),
-    singleValue: (provided: Object) => ({
+    singleValue: (provided: CSSObject) => ({
       ...provided,
       color: 'white',
     }),


### PR DESCRIPTION
There was a bug when trying to work with overloaded function, e.g.: check the `claimComp` function of `0xbafe01ff935c7305907c33bf824352ee5979b526` on mainnet.

This PR fixes the bug, and adds params to overloaded function names in the select so it's possible to tell them apart:
<img width="505" alt="image" src="https://user-images.githubusercontent.com/524089/207631585-f1437a19-112f-4ffe-9a40-01b50ab2b7a0.png">
